### PR TITLE
Remove Password Protect plugin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ Drop us a big shout-out if you have any questions, comments, or concerns. We're 
 - [Alt Akismet Addon](https://github.com/alt-design/Alt-Akismet-Addon)
 - [Alt Inbound Addon](https://github.com/alt-design/Alt-Inbound-Addon)
 - [Alt Sitemap Addon](https://github.com/alt-design/Alt-Sitemap-Addon)
-- [Alt Password Protect Addon](https://github.com/alt-design/Alt-Password-Protect-Addon)
 - [Alt Google 2FA Addon](https://github.com/alt-design/Alt-Google-2fa-Addon)
 
 ## Postcardware

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -20,7 +20,6 @@ dependencies:
   alt-design/alt-akismet: ^1.2
   alt-design/alt-cookies: ^1.1
   alt-design/alt-inbound: ^1.1
-  alt-design/alt-password-protect: ^1.2
   alt-design/alt-redirect: ^1.6
   alt-design/alt-seo: ^1.2
   alt-design/alt-sitemap: ^1.3


### PR DESCRIPTION
Removes the Password Protect plugin for new starter kit installs by default.